### PR TITLE
Added VSCode project settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    // Run DFTemplate extension for quest files
+    "files.associations": {
+        "{JH,QuestList-}*.txt": "dftemplate"
+    },
+    // Settings for DFTemplate extension
+    "[dftemplate]": {
+        "editor.formatOnSave": true,
+        "editor.formatOnType": true
+    },
+}


### PR DESCRIPTION
This is a settings file for the project folder when opened in VS Code, i though you might be interested in it :)

 It does two things:
* Set associations for quest files and tables, leaving txt readmes unaltered.
* Enable formatting features.

Putting this file here you can provide a ready to use configuration and ensure a consistent style for all quests if someone else contributes to this repository and makes a pull request.